### PR TITLE
Adiciona a operação a lista de operações enquanto na dentro da critical section

### DIFF
--- a/PanamahSDK.Processor.pas
+++ b/PanamahSDK.Processor.pas
@@ -263,9 +263,11 @@ procedure TPanamahBatchProcessor.AddOperationToCurrentBatch(AOperationType: TPan
   AModel: IPanamahModel; AAssinanteId: Variant);
 begin
   DoOnBeforeObjectAddedToBatch(AModel, AAssinanteId);
-  FCurrentBatch.Add(TPanamahOperation.Create(AOperationType, AModel.Clone, AAssinanteId));
+
   FCriticalSection.Acquire;
   try
+    FCurrentBatch.Add(TPanamahOperation.Create(AOperationType, AModel.Clone, AAssinanteId));
+
     if BatchExpiredByCount(FConfig.BatchMaxCount) then
     begin
       ExpireCurrentBatch;


### PR DESCRIPTION
O que foi feito?
---
Movido a adição de operações a lista de operações para dentro da critical section.

Por que foi feito isso?
---
Para garantir a adição da operação a lista de operações.

Foi identificado um comportamento ocasional onde durante processo de salvamento da thread de controle de batchs é adicionado um registro, ocorrendo entre a extração para o arquivo e a limpeza da lista, fazendo com que o registro não vá para o arquivo e não permaneça na lista para a próxima execução.